### PR TITLE
add seeder file for skill association to programming area

### DIFF
--- a/server/migrations/20190516165313-create-programming-area.js
+++ b/server/migrations/20190516165313-create-programming-area.js
@@ -19,6 +19,10 @@ module.exports = {
       updatedAt: {
         allowNull: false,
         type: Sequelize.DATE
+      },
+      superId: {
+        type: Sequelize.INTEGER,
+        allowNull: true
       }
     });
   },

--- a/server/migrations/20190523000437-create-skill-programmingarea.js
+++ b/server/migrations/20190523000437-create-skill-programmingarea.js
@@ -1,0 +1,40 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('skill_programmingarea', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      ProgrammingAreaId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'programmingareas',
+          key: 'id'
+        }
+      },
+      SkillId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'skills',
+          key: 'id'
+        }
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('skill_programmingarea');
+  }
+};

--- a/server/models/ProgrammingArea.js
+++ b/server/models/ProgrammingArea.js
@@ -13,8 +13,16 @@ module.exports = (sequelize, DataTypes) => {
 
     ProgrammingArea.associate = (models) => {
         ProgrammingArea.belongsToMany(models.Skill, {
-            through: "Skill_ProgrammingArea"
+            through: 'Skill_ProgrammingArea'
         });
+        ProgrammingArea.hasMany(ProgrammingArea, {
+            as: 'Sub-Type',
+            foreignKey: 'superId'
+        });
+        ProgrammingArea.hasOne(ProgrammingArea, {
+            as: 'Super-Type',
+            foreignKey: 'superId'
+        })
     }
 
     return ProgrammingArea;

--- a/server/models/Skill.js
+++ b/server/models/Skill.js
@@ -24,12 +24,6 @@ module.exports = (sequelize, DataTypes) => {
     },
     { sequelize });
 
-    Skill.user_skill = {
-        self_rating: null,
-        employer_rating: null,
-        interest: null
-    }
-
     Skill.associate = (models) => {
         Skill.belongsToMany(models.User, {
             through: models.user_skill

--- a/server/models/skill_programmingarea.js
+++ b/server/models/skill_programmingarea.js
@@ -1,0 +1,19 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  class skill_programmingarea extends sequelize.Sequelize.Model {}
+  
+  skill_programmingarea.init({
+    ProgrammingAreaId: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    SkillId: {
+      type: DataTypes.STRING,
+      allowNull: false
+    }
+  }, { sequelize });
+  skill_programmingarea.associate = function(models) {
+    // associations can be defined here
+  };
+  return skill_programmingarea;
+};

--- a/server/models/user_skill.js
+++ b/server/models/user_skill.js
@@ -1,14 +1,20 @@
 'use strict';
 module.exports = (sequelize, DataTypes) => {
-  const user_skill = sequelize.define('user_skill', {
+
+  class user_skill extends sequelize.Sequelize.Model {}
+
+  user_skill.init({
     self_rating: DataTypes.INTEGER,
     employer_rating: DataTypes.INTEGER,
     interest: DataTypes.INTEGER,
     UserEmail: DataTypes.STRING,
     SkillId: DataTypes.INTEGER
-  }, {});
+  }, {sequelize});
+  
   user_skill.associate = function(models) {
     // associations can be defined here
   };
+
   return user_skill;
+  
 };

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -68,7 +68,7 @@ module.exports = (db) => {
     });
 
     router.post('/api/newUser', (req, res) => {
-        db.User.create(req.body).then(result => res.send(result));
+        db.User.create({email: req.body.email}).then(result => res.send(result));
     });
 
     router.post('/api/getoneuser', (req, res) => {
@@ -78,6 +78,49 @@ module.exports = (db) => {
                 model: db.Skill
             }]
         }).then(result => res.json(result));
+    });
+
+    router.patch('/api/addprogrammingareastoskill', (req, res) => {
+
+        db.Skill.findOne({
+            where: { id: req.body.skillId }
+        }).then( skill => {
+            console.log(Object.getPrototypeOf(skill));
+            db.ProgrammingArea.findAll({
+                where: { 
+                    id: {
+                        [Op.or]: req.body.areaIds 
+                    }
+                }
+            }).then( programmingAreas => {
+                skill.addProgrammingAreas(programmingAreas)
+                    .then(response => {
+                        res.json(response);
+                        return;
+                    });
+            });   
+        });
+    });
+
+    router.patch('/api/addskillstoprogrammingarea', (req, res) => {
+
+        db.ProgrammingArea.findOne({
+            where: { id: req.body.areaId}
+        }).then( programmingArea => {
+            db.Skill.findAll({
+                where: {
+                    id: {
+                        [Op.or]: req.body.skillIds
+                    }
+                }
+            }).then( skills => {
+                programmingArea.addSkills( skills )
+                    .then(response => {
+                        res.json(response);
+                        return
+                    });
+            });
+        });
     });
 
     return router;

--- a/server/seeders/20190516175128-Skill.js
+++ b/server/seeders/20190516175128-Skill.js
@@ -56,6 +56,7 @@ module.exports = {
       { name: 'Kotlin', createdAt: new Date(), updatedAt: new Date() },
       { name: 'VirtualBox', createdAt: new Date(), updatedAt: new Date() },
       { name: 'Vagrant', createdAt: new Date(), updatedAt: new Date() },
+      { name: 'JavaScript', createdAt: new Date(), updatedAt: new Date() },
     ]);
   },
 

--- a/server/seeders/20190522233924-role.js
+++ b/server/seeders/20190522233924-role.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.bulkInsert('roles', [
+      {
+        name: "super-admin",
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        name: "admin",
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        name: "user",
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ])
+  },
+
+  down: (queryInterface, Sequelize) => {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.bulkDelete('People', null, {});
+    */
+  }
+};

--- a/server/seeders/20190522234306-programmingarea.js
+++ b/server/seeders/20190522234306-programmingarea.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.bulkInsert('programmingareas', [
+      {
+        name: "Client",
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        name: "Server",
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        name: "DevOps",
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+    ])
+  },
+
+  down: (queryInterface, Sequelize) => {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.bulkDelete('People', null, {});
+    */
+  }
+};

--- a/server/seeders/20190522235313-skill_programmingarea.js
+++ b/server/seeders/20190522235313-skill_programmingarea.js
@@ -1,0 +1,67 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.bulkInsert('skill_programmingarea', [{"id":1, "ProgrammingAreaId":1, "SkillId":1, "createdAt":"2019-05-23 19:14:37", "updatedAt":"2019-05-23 19:14:37"},
+    {"id":2, "ProgrammingAreaId":1, "SkillId":2, "createdAt":"2019-05-23 19:19:10", "updatedAt":"2019-05-23 19:19:10"},
+    {"id":3, "ProgrammingAreaId":1, "SkillId":3, "createdAt":"2019-05-23 19:19:10", "updatedAt":"2019-05-23 19:19:10"},
+    {"id":4, "ProgrammingAreaId":1, "SkillId":5, "createdAt":"2019-05-23 19:19:10", "updatedAt":"2019-05-23 19:19:10"},
+    {"id":5, "ProgrammingAreaId":1, "SkillId":6, "createdAt":"2019-05-23 19:19:10", "updatedAt":"2019-05-23 19:19:10"},
+    {"id":6, "ProgrammingAreaId":1, "SkillId":10, "createdAt":"2019-05-23 19:19:10", "updatedAt":"2019-05-23 19:19:10"},
+    {"id":7, "ProgrammingAreaId":1, "SkillId":11, "createdAt":"2019-05-23 19:19:10", "updatedAt":"2019-05-23 19:19:10"},
+    {"id":8, "ProgrammingAreaId":1, "SkillId":12, "createdAt":"2019-05-23 19:19:10", "updatedAt":"2019-05-23 19:19:10"},
+    {"id":9, "ProgrammingAreaId":1, "SkillId":13, "createdAt":"2019-05-23 19:19:10", "updatedAt":"2019-05-23 19:19:10"},
+    {"id":10, "ProgrammingAreaId":1, "SkillId":30, "createdAt":"2019-05-23 19:19:10", "updatedAt":"2019-05-23 19:19:10"},
+    {"id":11, "ProgrammingAreaId":1, "SkillId":34, "createdAt":"2019-05-23 19:19:10", "updatedAt":"2019-05-23 19:19:10"},
+    {"id":12, "ProgrammingAreaId":1, "SkillId":35, "createdAt":"2019-05-23 19:19:10", "updatedAt":"2019-05-23 19:19:10"},
+    {"id":13, "ProgrammingAreaId":1, "SkillId":39, "createdAt":"2019-05-23 19:19:10", "updatedAt":"2019-05-23 19:19:10"},
+    {"id":14, "ProgrammingAreaId":1, "SkillId":46, "createdAt":"2019-05-23 19:19:10", "updatedAt":"2019-05-23 19:19:10"},
+    {"id":15, "ProgrammingAreaId":1, "SkillId":47, "createdAt":"2019-05-23 19:19:10", "updatedAt":"2019-05-23 19:19:10"},
+    {"id":16, "ProgrammingAreaId":1, "SkillId":54, "createdAt":"2019-05-23 19:19:10", "updatedAt":"2019-05-23 19:19:10"},
+    {"id":17, "ProgrammingAreaId":2, "SkillId":8, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":18, "ProgrammingAreaId":2, "SkillId":9, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":19, "ProgrammingAreaId":2, "SkillId":15, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":20, "ProgrammingAreaId":2, "SkillId":16, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":21, "ProgrammingAreaId":2, "SkillId":17, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":22, "ProgrammingAreaId":2, "SkillId":18, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":23, "ProgrammingAreaId":2, "SkillId":19, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":24, "ProgrammingAreaId":2, "SkillId":20, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":25, "ProgrammingAreaId":2, "SkillId":21, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":26, "ProgrammingAreaId":2, "SkillId":22, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":27, "ProgrammingAreaId":2, "SkillId":23, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":28, "ProgrammingAreaId":2, "SkillId":26, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":29, "ProgrammingAreaId":2, "SkillId":29, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":30, "ProgrammingAreaId":2, "SkillId":31, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":31, "ProgrammingAreaId":2, "SkillId":32, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":32, "ProgrammingAreaId":2, "SkillId":45, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":33, "ProgrammingAreaId":2, "SkillId":49, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":34, "ProgrammingAreaId":2, "SkillId":50, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":35, "ProgrammingAreaId":2, "SkillId":51, "createdAt":"2019-05-23 19:19:55", "updatedAt":"2019-05-23 19:19:55"},
+    {"id":36, "ProgrammingAreaId":3, "SkillId":4, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"},
+    {"id":37, "ProgrammingAreaId":3, "SkillId":7, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"},
+    {"id":38, "ProgrammingAreaId":3, "SkillId":24, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"},
+    {"id":39, "ProgrammingAreaId":3, "SkillId":25, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"},
+    {"id":40, "ProgrammingAreaId":3, "SkillId":27, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"},
+    {"id":41, "ProgrammingAreaId":3, "SkillId":28, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"},
+    {"id":42, "ProgrammingAreaId":3, "SkillId":33, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"},
+    {"id":43, "ProgrammingAreaId":3, "SkillId":36, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"},
+    {"id":44, "ProgrammingAreaId":3, "SkillId":40, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"},
+    {"id":45, "ProgrammingAreaId":3, "SkillId":41, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"},
+    {"id":46, "ProgrammingAreaId":3, "SkillId":42, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"},
+    {"id":47, "ProgrammingAreaId":3, "SkillId":43, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"},
+    {"id":48, "ProgrammingAreaId":3, "SkillId":44, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"},
+    {"id":49, "ProgrammingAreaId":3, "SkillId":47, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"},
+    {"id":50, "ProgrammingAreaId":3, "SkillId":52, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"},
+    {"id":51, "ProgrammingAreaId":3, "SkillId":53, "createdAt":"2019-05-23 19:20:39", "updatedAt":"2019-05-23 19:20:39"}])
+  },
+
+  down: (queryInterface, Sequelize) => {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.bulkDelete('People', null, {});
+    */
+  }
+};


### PR DESCRIPTION
Each skill is now associated with a focused area of programming.
A skill can have additional programming areas assigned to it at: 
~~~
patch('/api/addprogrammingareatoskill')

// request body should look like
    {
        skillId: id of skill to assign to programming areas
        areaIds: ids of programming areas to add skill to
    }
~~~

A programming area can new skills added to it at
~~~
patch('/api/addskillstoprogrammingarea')

//request body should look like 
    {
        areaId: id of programming area,
        skillIds: array of skill ids to be added to referenced programming area
    }
~~~